### PR TITLE
chore: 🤖 bump vscode-oniguruma version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,11 +83,11 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.13.10.tgz",
-      "integrity": "sha512-x/XYVQ1h684pp1mJwOV4CyvqZXqbc8CMsMGUnAbuc82ZCdv1U63w5RSUzgDSXQHG5Rps/kiksH6g2D5BuaKyXg==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.14.5.tgz",
+      "integrity": "sha512-cBbwXj3F2xjnQJ0ERaFRLjxhUSBYsQPXJ7CERz/ecx6q6hzQ99eTflAPFC3ks4q/IG4CWupNVdflc4jlFBJVsg==",
       "requires": {
-        "core-js-pure": "^3.0.0",
+        "core-js-pure": "^3.14.0",
         "regenerator-runtime": "^0.13.4"
       }
     },
@@ -432,9 +432,9 @@
       "dev": true
     },
     "blade-formatter": {
-      "version": "1.11.5",
-      "resolved": "https://registry.npmjs.org/blade-formatter/-/blade-formatter-1.11.5.tgz",
-      "integrity": "sha512-BtRTC2mbCw0etWomcUHkefqAzInzOYO7FoqyhwQrat9+2PYhF0qcnqjG37UPJggFW0ohqHXsPXwnDYJp7mquhw==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/blade-formatter/-/blade-formatter-1.11.6.tgz",
+      "integrity": "sha512-N00KagtvYZLSDzHoeAzU5q6PqyyWOlYStmGv82fS6NIV1Ob+9BFpBWJ4pNTmtMqUgEE14EoT9QkxBSQEb1jnmw==",
       "requires": {
         "@prettier/plugin-php": "github:shufo/plugin-php#a18627e03748ee5dd0218b7685a6564672f6c3e7",
         "aigle": "^1.14.1",
@@ -623,9 +623,9 @@
       }
     },
     "config-chain": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
-      "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
       "requires": {
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
@@ -867,9 +867,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.10.1.tgz",
-      "integrity": "sha512-PeyJH2SE0KuxY5eCGNWA+W+CeDpB6M1PN3S7Am7jSv/Ttuxz2SnWbIiVQOn/TDaGaGtxo8CRWHkXwJscbUHtVw=="
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.14.0.tgz",
+      "integrity": "sha512-YVh+LN2FgNU0odThzm61BsdkwrbrchumFq3oztnE9vTKC4KS2fvnPmcx8t6jnqAyOTCTF4ZSiuK8Qhh7SNcL4g=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -960,9 +960,9 @@
       "dev": true
     },
     "detect-indent": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
-      "integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="
     },
     "diff": {
       "version": "5.0.0",
@@ -2076,9 +2076,9 @@
       "dev": true
     },
     "linguist-languages": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/linguist-languages/-/linguist-languages-7.14.0.tgz",
-      "integrity": "sha512-VqnUYHOSqRqAGnIl+7SCnFxK+sX0x7LXe5qn0TG6t9SViofQgN7272PLCFZ/lgkT7tAO5CA/2pCsZGlGvGhfWA=="
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/linguist-languages/-/linguist-languages-7.15.0.tgz",
+      "integrity": "sha512-qkSSNDjDDycZ2Wcw+GziNBB3nNo3ddYUInM/PL8Amgwbd9RQ/BKGj2/1d6mdxKgBFnUqZuaDbkIwkE4KUwwmtQ=="
     },
     "listenercount": {
       "version": "1.0.1",
@@ -2216,9 +2216,9 @@
       "dev": true
     },
     "mem": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.0.tgz",
-      "integrity": "sha512-FIkgXo0kTi3XpvaznV5Muk6Y6w8SkdmRXcY7ZLonQesuYezp59UooLxAVBcGuN6PH2tXN84mR3vyzSc6oSMUfA==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
+      "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
       "requires": {
         "map-age-cleaner": "^0.1.3",
         "mimic-fn": "^3.1.0"
@@ -2771,9 +2771,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.1.tgz",
+      "integrity": "sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA=="
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "vscode-test": "^1.5.2"
   },
   "dependencies": {
-    "blade-formatter": "^1.11.5",
+    "blade-formatter": "^1.11.6",
     "esm": "^3.2.25",
     "find-config": "^1.0.0",
     "ignore": "^5.1.8"

--- a/test/runTest.js
+++ b/test/runTest.js
@@ -4,6 +4,8 @@ const { runTests } = require("vscode-test");
 
 async function main() {
   try {
+    // vscode version
+    const version = "1.57.0";
     // The folder containing the Extension Manifest package.json
     // Passed to `--extensionDevelopmentPath`
     const extensionDevelopmentPath = path.resolve(__dirname, "../");
@@ -19,6 +21,7 @@ async function main() {
 
     // Download VS Code, unzip it and run the integration test
     await runTests({
+      version,
       extensionDevelopmentPath,
       extensionTestsPath,
       launchArgs,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
vscode-blade-formatter 1.11.2 is not working on vscode 1.57

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #137 

## Solution
- bump vscode-oniguruma used in blade-formatter and bump blade-formatter for vscode-blade-formatter