### PR TITLE
chore: 🤖 revert blade-formatter to 1.11.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -432,9 +432,9 @@
       "dev": true
     },
     "blade-formatter": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/blade-formatter/-/blade-formatter-1.11.6.tgz",
-      "integrity": "sha512-N00KagtvYZLSDzHoeAzU5q6PqyyWOlYStmGv82fS6NIV1Ob+9BFpBWJ4pNTmtMqUgEE14EoT9QkxBSQEb1jnmw==",
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/blade-formatter/-/blade-formatter-1.11.5.tgz",
+      "integrity": "sha512-BtRTC2mbCw0etWomcUHkefqAzInzOYO7FoqyhwQrat9+2PYhF0qcnqjG37UPJggFW0ohqHXsPXwnDYJp7mquhw==",
       "requires": {
         "@prettier/plugin-php": "github:shufo/plugin-php#a18627e03748ee5dd0218b7685a6564672f6c3e7",
         "aigle": "^1.14.1",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "vscode-test": "^1.5.2"
   },
   "dependencies": {
-    "blade-formatter": "^1.11.6",
+    "blade-formatter": "1.11.5",
     "esm": "^3.2.25",
     "find-config": "^1.0.0",
     "ignore": "^5.1.8"

--- a/test/runTest.js
+++ b/test/runTest.js
@@ -5,7 +5,7 @@ const { runTests } = require("vscode-test");
 async function main() {
   try {
     // vscode version
-    const version = "1.57.0";
+    const version = "1.56.0";
     // The folder containing the Extension Manifest package.json
     // Passed to `--extensionDevelopmentPath`
     const extensionDevelopmentPath = path.resolve(__dirname, "../");


### PR DESCRIPTION
To avoid breaking change in vscode api issue

<!--- Provide a general summary of your changes in the Title above -->

## Description

- There has a breaking change in vscode API between 1.56 and 1.57 that vscode-blade-formatter depends on
  - To avoid this issue, revert blade-formatter to 1.11.5 firstly and specify version 1.11.5 explicitly and then re-bump up blade-formatter to latest version and specify supported vscode engine as `^1.57.0`

## Related Issues

<!--- Describe your changes in detail -->

- https://github.com/shufo/vscode-blade-formatter/pull/139
