### PR TITLE
feat: Add json schema for config file and enable "jsonValidation" feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,12 @@
         "extensions": [
           ".blade.php"
         ]
+      },
+      {
+        "id": "json",
+        "filenames": [
+          ".bladeformatterrc"
+        ]
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,16 @@
   "icon": "icon.png",
   "main": "./dist/extension.js",
   "contributes": {
+    "jsonValidation": [
+      {
+        "fileMatch": ".bladeformatterrc.json",
+        "url": "./schemas/bladeformatterrc.schema.json"
+      },
+      {
+        "fileMatch": ".bladeformatterrc",
+        "url": "./schemas/bladeformatterrc.schema.json"
+      }
+    ],
     "languages": [
       {
         "id": "blade",

--- a/schemas/bladeformatterrc.schema.json
+++ b/schemas/bladeformatterrc.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Schema for .bladeformatterrc.json",
+  "properties": {
+    "indentSize": {
+      "description": "An indent size",
+      "default": 4,
+      "type": "integer"
+    },
+    "wrapLineLength": {
+      "description": "The length of line wrap size",
+      "default": 120,
+      "type": "integer"
+    },
+    "wrapAttributues": {
+      "default": "auto",
+      "description": "The way to wrap attributes",
+      "type": "string",
+      "enum": [
+        "auto",
+        "force",
+        "force-aligned",
+        "force-expand-multiline",
+        "aligned-multiple",
+        "preserve",
+        "preserve-aligned"
+      ]
+    },
+    "endWithNewLine": {
+      "description": "End output with newline",
+      "default": true,
+      "type": "boolean"
+    },
+    "useTabs": {
+      "description": "Indent with tabs instead of spaces",
+      "default": false,
+      "type": "boolean"
+    }
+  }
+}


### PR DESCRIPTION
## Description

Do you know the JSON schemas?

- <https://code.visualstudio.com/api/references/contribution-points#contributes.jsonValidation>
- <https://code.visualstudio.com/docs/languages/json#_json-schemas-and-settings>

I created a schema file for `.bladeformatterrc.json`.

I used this schema file to allow you to do auto-completion, linting and etc.

## Related Issue

None

## DEMO (mp4)

https://user-images.githubusercontent.com/188642/151112057-52702543-856c-416d-9a6a-4e61afb4749c.mp4

## Misc

If you don't need this feature at this time, don't worry about it, just close this PR.
