### PR TITLE
feat: bump blade-formatter to 1.27.1

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -12,6 +12,7 @@ jobs:
       - name: Assign author to created issue or PR
         uses: technote-space/assign-author@v1
       - name: "Auto-assign issue"
-        uses: pozil/auto-assign-issue@v1.8.0
+        uses: pozil/auto-assign-issue@v1.9.0
         with:
+          allowNoAssignees: true
           assignees: shufo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        vscode_version: ["1.69.2", "1.59.0"]
+        vscode_version: ["stable", "1.69.2", "1.59.0"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,11 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+      - uses: actions/cache@v3
+        id: vscode-test-cache
+        with:
+          path: .vscode-test
+          key: ${{ runner.os }}-vscode-test-${{ matrix.vscode_version }}
       - name: Install dependencies
         run: yarn install
 

--- a/README.md
+++ b/README.md
@@ -24,15 +24,17 @@ You can also format by same syntax programmatically with [blade-formatter](https
 
 ## Extension Settings
 
-| setting                                             | description                                                                                                                      | default |
-| :-------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------- | :------ |
-| `Blade Formatter: format Enabled`                   | Whether it enables or not                                                                                                        | true    |
-| `Blade Formatter: format Indent Size`               | An indent size                                                                                                                   | 4       |
-| `Blade Formatter: format Wrap Line Length`          | The length of line wrap size                                                                                                     | 120     |
-| `Blade Formatter: format Wrap Attributes`           | The way to wrap attributes. `[auto\|force\|force-aligned\|force-expand-multiline\|aligned-multiple\|preserve\|preserve-aligned]` | `auto`  |
-| `Blade Formatter: format use Tabs`                  | Use tab as indentation character                                                                                                 | false   |
-| `Blade Formatter: format Sort Tailwind Css Classes` | Sort Tailwind CSS classes automatically                                                                                          | false   |
-| `Blade Formatter: Dont Show New Version Message`    | If set to 'true', the new version message won't be shown anymore.                                                                | false   |
+| setting                                             | description                                                                                                                                                                                                                                                     | default |
+| :-------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------ |
+| `Blade Formatter: format Enabled`                   | Whether it enables or not                                                                                                                                                                                                                                       | true    |
+| `Blade Formatter: format Indent Size`               | An indent size                                                                                                                                                                                                                                                  | 4       |
+| `Blade Formatter: format Wrap Line Length`          | The length of line wrap size                                                                                                                                                                                                                                    | 120     |
+| `Blade Formatter: format Wrap Attributes`           | The way to wrap attributes. `[auto\|force\|force-aligned\|force-expand-multiline\|aligned-multiple\|preserve\|preserve-aligned]`                                                                                                                                | `auto`  |
+| `Blade Formatter: format use Tabs`                  | Use tab as indentation character                                                                                                                                                                                                                                | false   |
+| `Blade Formatter: format Sort Tailwind Css Classes` | Sort Tailwind CSS classes automatically                                                                                                                                                                                                                         | false   |
+| `Blade Formatter: format Sort HTML Attributes`      | Sort HTML Attributes in the specified order. [`none` \| `alphabetical` \| [`code-guide`](https://codeguide.co/) \| [`idiomatic`](https://github.com/necolas/idiomatic-html#attribute-order) \| [`vuejs`](https://eslint.vuejs.org/rules/attributes-order.html)] | `none`  |
+| `Blade Formatter: format No Multiple Empty Lines`   | Collapses multiple blank lines into a single blank line.                                                                                                                                                                                                        | false   |
+| `Blade Formatter: Dont Show New Version Message`    | If set to 'true', the new version message won't be shown anymore.                                                                                                                                                                                               | false   |
 
 ## Configuration file: .bladeformatterrc.json or .bladeformatterrc
 
@@ -47,7 +49,9 @@ Configuration file will like below:
     "wrapLineLength": 120,
     "endWithNewLine": true,
     "useTabs": false,
-    "sortTailwindcssClasses": true
+    "sortTailwindcssClasses": true,
+    "sortHtmlAttributes": "none",
+    "noMultipleEmptyLines": false
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -119,6 +119,11 @@
           ],
           "markdownDescription": "Sort HTML Attributes in the specified order"
         },
+        "bladeFormatter.format.noMultipleEmptyLines": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Collapses multiple blank lines into a single blank line"
+        },
         "bladeFormatter.misc.dontShowNewVersionMessage": {
           "type": "boolean",
           "default": false,

--- a/package.json
+++ b/package.json
@@ -107,6 +107,18 @@
           "default": false,
           "markdownDescription": "Sort Tailwindcss Classes automatically"
         },
+        "bladeFormatter.format.sortHtmlAttributes": {
+          "type": "string",
+          "default": "none",
+          "enum": [
+            "none",
+            "alphabetical",
+            "code-guide",
+            "idiomatic",
+            "vuejs"
+          ],
+          "markdownDescription": "Sort HTML Attributes in the specified order"
+        },
         "bladeFormatter.misc.dontShowNewVersionMessage": {
           "type": "boolean",
           "default": false,

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
   },
   "dependencies": {
     "ajv": "^8.11.0",
-    "blade-formatter": "^1.27.0",
+    "blade-formatter": "^1.27.1",
     "find-config": "^1.0.0",
     "ignore": "^5.1.8",
     "vscode-extension-telemetry": "^0.4.5"

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
   },
   "dependencies": {
     "ajv": "^8.11.0",
-    "blade-formatter": "^1.26.17",
+    "blade-formatter": "^1.27.0",
     "find-config": "^1.0.0",
     "ignore": "^5.1.8",
     "vscode-extension-telemetry": "^0.4.5"

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -24,6 +24,7 @@ export const formatFromCommand =
                 useTabs: extConfig.useTabs,
                 sortTailwindcssClasses: extConfig.sortTailwindcssClasses,
                 sortHtmlAttributes: extConfig.sortHtmlAttributes ?? 'none',
+                noMultipleEmptyLines: extConfig.noMultipleEmptyLines,
                 ...runtimeConfig,
             };
             const originalText = editor.document.getText();

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -23,6 +23,7 @@ export const formatFromCommand =
                 wrapAttributes: extConfig.wrapAttributes,
                 useTabs: extConfig.useTabs,
                 sortTailwindcssClasses: extConfig.sortTailwindcssClasses,
+                sortHtmlAttributes: extConfig.sortHtmlAttributes ?? 'none',
                 ...runtimeConfig,
             };
             const originalText = editor.document.getText();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -80,6 +80,7 @@ export function activate(context: ExtensionContext) {
                     wrapAttributes: extConfig.wrapAttributes,
                     useTabs: extConfig.useTabs,
                     sortTailwindcssClasses: extConfig.sortTailwindcssClasses,
+                    sortHtmlAttributes: extConfig.sortHtmlAttributes ?? 'none',
                     ...runtimeConfig,
                 };
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -81,6 +81,7 @@ export function activate(context: ExtensionContext) {
                     useTabs: extConfig.useTabs,
                     sortTailwindcssClasses: extConfig.sortTailwindcssClasses,
                     sortHtmlAttributes: extConfig.sortHtmlAttributes ?? 'none',
+                    noMultipleEmptyLines: extConfig.noMultipleEmptyLines,
                     ...runtimeConfig,
                 };
 

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -22,6 +22,7 @@ export interface RuntimeConfig {
     useTabs?: boolean;
     sortTailwindcssClasses?: boolean;
     sortHtmlAttributes?: string;
+    noMultipleEmptyLines?: boolean;
 }
 
 const configFileNames = [".bladeformatterrc.json", ".bladeformatterrc"];
@@ -54,6 +55,7 @@ export function readRuntimeConfig(filePath: string): RuntimeConfig | undefined {
             useTabs: { type: 'boolean' },
             sortTailwindcssClasses: { type: 'boolean' },
             sortHtmlAttributes: { type: 'string' },
+            noMultipleEmptyLines: { type: 'boolean' },
         },
         additionalProperties: true,
     };

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -21,6 +21,7 @@ export interface RuntimeConfig {
     endWithNewline?: boolean;
     useTabs?: boolean;
     sortTailwindcssClasses?: boolean;
+    sortHtmlAttributes?: string;
 }
 
 const configFileNames = [".bladeformatterrc.json", ".bladeformatterrc"];
@@ -52,6 +53,7 @@ export function readRuntimeConfig(filePath: string): RuntimeConfig | undefined {
             endWithNewline: { type: 'boolean' },
             useTabs: { type: 'boolean' },
             sortTailwindcssClasses: { type: 'boolean' },
+            sortHtmlAttributes: { type: 'string' },
         },
         additionalProperties: true,
     };

--- a/src/test/fixtures/project/withConfig/noMultipleEmptyLines/.bladeformatterrc.json
+++ b/src/test/fixtures/project/withConfig/noMultipleEmptyLines/.bladeformatterrc.json
@@ -1,0 +1,3 @@
+{
+  "noMultipleEmptyLines": true
+}

--- a/src/test/fixtures/project/withConfig/noMultipleEmptyLines/formatted.index.blade.php
+++ b/src/test/fixtures/project/withConfig/noMultipleEmptyLines/formatted.index.blade.php
@@ -1,0 +1,7 @@
+<div>
+    foo
+</div>
+
+<div>
+    bar
+</div>

--- a/src/test/fixtures/project/withConfig/noMultipleEmptyLines/index.blade.php
+++ b/src/test/fixtures/project/withConfig/noMultipleEmptyLines/index.blade.php
@@ -1,0 +1,11 @@
+<div>
+foo
+</div>
+
+
+
+
+
+<div>
+bar
+</div>

--- a/src/test/fixtures/project/withConfig/sortHtmlAttributes/.bladeformatterrc.json
+++ b/src/test/fixtures/project/withConfig/sortHtmlAttributes/.bladeformatterrc.json
@@ -1,0 +1,3 @@
+{
+  "sortHtmlAttributes": "code-guide"
+}

--- a/src/test/fixtures/project/withConfig/sortHtmlAttributes/formatted.index.blade.php
+++ b/src/test/fixtures/project/withConfig/sortHtmlAttributes/formatted.index.blade.php
@@ -1,0 +1,3 @@
+<a class="bar" id="foo" href="...">
+    baz
+</a>

--- a/src/test/fixtures/project/withConfig/sortHtmlAttributes/index.blade.php
+++ b/src/test/fixtures/project/withConfig/sortHtmlAttributes/index.blade.php
@@ -1,0 +1,3 @@
+<a href="..." id="foo" class="bar">
+baz
+</a>

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -61,6 +61,22 @@ suite("Extension Test Suite", () => {
         );
     });
 
+    test("Should format file with runtime config / sortHtmlAttributes", async function (this: any) {
+        this.timeout(20000);
+        await formatSameAsBladeFormatter(
+            "withConfig/sortHtmlAttributes/index.blade.php",
+            "withConfig/sortHtmlAttributes/formatted.index.blade.php"
+        );
+    });
+
+    test("Should format file with runtime config / noMultipleEmptyLines", async function (this: any) {
+        this.timeout(20000);
+        await formatSameAsBladeFormatter(
+            "withConfig/noMultipleEmptyLines/index.blade.php",
+            "withConfig/noMultipleEmptyLines/formatted.index.blade.php"
+        );
+    });
+
     test("Format command exists in command list", async function () {
         const commands = await vscode.commands.getCommands();
         assert(commands.includes(ExtensionConstants.formatCommandKey));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2155,10 +2155,10 @@ binary@~0.3.0:
     buffers "~0.1.1"
     chainsaw "~0.1.0"
 
-blade-formatter@^1.27.0:
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/blade-formatter/-/blade-formatter-1.27.0.tgz#3c052aa83af5208e272477c1442107d5b102e178"
-  integrity sha512-JyaUS10fAKVcpBnk6kC2/SyNx1iIWIpoPVcOIIvYYwVNAqyRMpf75Tc0X1+VJ3r7Ck0S9IG305hiPlj2FeNUzQ==
+blade-formatter@^1.27.1:
+  version "1.27.1"
+  resolved "https://registry.yarnpkg.com/blade-formatter/-/blade-formatter-1.27.1.tgz#1cd0bf20e41e41daa8c5480d44bd7cf38e63f63b"
+  integrity sha512-NjGVwl/L6OFiJcTNR3wkpsxa+apdDc5Ga5wuNhKLgOIQ0YibktZY4hahJivTK1kin0pfIIB/YqW2zxtDZSLZJw==
   dependencies:
     "@prettier/plugin-php" "^0.18.0"
     "@shufo/tailwindcss-class-sorter" "^1.0.3"
@@ -2169,7 +2169,7 @@ blade-formatter@^1.27.0:
     detect-indent "^6.0.0"
     find-config "^1.0.0"
     glob "^8.0.1"
-    html-attribute-sorter "^0.4.0"
+    html-attribute-sorter "^0.4.1"
     ignore "^5.1.8"
     js-beautify "^1.14.0"
     lodash "^4.17.19"
@@ -3678,10 +3678,10 @@ hosted-git-info@^4.0.0, hosted-git-info@^4.0.1:
   dependencies:
     lru-cache "^6.0.0"
 
-html-attribute-sorter@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/html-attribute-sorter/-/html-attribute-sorter-0.4.0.tgz#c9021e51f8170fd971296497884fc32d3fe18db8"
-  integrity sha512-GxGTu1FtmABg/5AUovWnIxmOEJMvZOMqBnmRuut2bLfxy/Tn+pI93l0devqaB9UkG8UoviTLJtOqz1+DBHqtbA==
+html-attribute-sorter@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/html-attribute-sorter/-/html-attribute-sorter-0.4.1.tgz#6f5b54a77654a2b865ecb036858b279906bc3b58"
+  integrity sha512-7+SzUuTnY9pdLVbe/6U41ZFd9CP4Z5HgRYwZkJNHSOHjNKSYIkZoYtJB2uxPDEXacxf19H6Mz9C/GsXeANLSKg==
 
 http-proxy-agent@^4.0.1:
   version "4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2155,10 +2155,10 @@ binary@~0.3.0:
     buffers "~0.1.1"
     chainsaw "~0.1.0"
 
-blade-formatter@^1.26.17:
-  version "1.26.17"
-  resolved "https://registry.yarnpkg.com/blade-formatter/-/blade-formatter-1.26.17.tgz#14d2fcca7052a5ab7e0ad3603562b62575e40cfc"
-  integrity sha512-sEP8JjDvlfg6QdLrWQ19RfpUf869xg8PgBGSV8r1FRuYTf93iWHKTqFqw8REdDAq6GdC3QKE6jURB5/3vZQVmQ==
+blade-formatter@^1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/blade-formatter/-/blade-formatter-1.27.0.tgz#3c052aa83af5208e272477c1442107d5b102e178"
+  integrity sha512-JyaUS10fAKVcpBnk6kC2/SyNx1iIWIpoPVcOIIvYYwVNAqyRMpf75Tc0X1+VJ3r7Ck0S9IG305hiPlj2FeNUzQ==
   dependencies:
     "@prettier/plugin-php" "^0.18.0"
     "@shufo/tailwindcss-class-sorter" "^1.0.3"
@@ -2169,6 +2169,7 @@ blade-formatter@^1.26.17:
     detect-indent "^6.0.0"
     find-config "^1.0.0"
     glob "^8.0.1"
+    html-attribute-sorter "^0.4.0"
     ignore "^5.1.8"
     js-beautify "^1.14.0"
     lodash "^4.17.19"
@@ -3676,6 +3677,11 @@ hosted-git-info@^4.0.0, hosted-git-info@^4.0.1:
   integrity sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==
   dependencies:
     lru-cache "^6.0.0"
+
+html-attribute-sorter@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/html-attribute-sorter/-/html-attribute-sorter-0.4.0.tgz#c9021e51f8170fd971296497884fc32d3fe18db8"
+  integrity sha512-GxGTu1FtmABg/5AUovWnIxmOEJMvZOMqBnmRuut2bLfxy/Tn+pI93l0devqaB9UkG8UoviTLJtOqz1+DBHqtbA==
 
 http-proxy-agent@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR bump blade-formatter to 1.27.1.

This version will include new options

- `Sort Html Attributes`: Sort HTML Attributes in the specified order
- `No Multiple Empty Lines`: Collapses multiple blank lines into a single blank line

and fixed tab spacing related issues.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- #413
- #473
- #424
- #422

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests
