### PR TITLE
feat:  add option noPhpSyntaxCheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ You can also format by same syntax programmatically with [blade-formatter](https
 | `Blade Formatter: format use Tabs`                  | Use tab as indentation character                                                                                                                                                                                                                                                | false   |
 | `Blade Formatter: format Sort Tailwind Css Classes` | Sort Tailwind CSS classes automatically                                                                                                                                                                                                                                         | false   |
 | `Blade Formatter: format Sort HTML Attributes`      | Sort HTML Attributes in the specified order. [`none` \| `alphabetical` \| [`code-guide`](https://codeguide.co/#attribute-order) \| [`idiomatic`](https://github.com/necolas/idiomatic-html#attribute-order) \| [`vuejs`](https://eslint.vuejs.org/rules/attributes-order.html)] | `none`  |
+| `Blade Formatter: format No PHP Syntax Check`       | Disable PHP Syntax check. Enabling this will suppress syntax error reporing.                                                                                                                                                                                                    | false   |
 | `Blade Formatter: Dont Show New Version Message`    | If set to 'true', the new version message won't be shown anymore.                                                                                                                                                                                                               | false   |
 
 ## Configuration file: .bladeformatterrc.json or .bladeformatterrc
@@ -51,7 +52,8 @@ Configuration file will like below:
     "noMultipleEmptyLines": false,
     "useTabs": false,
     "sortTailwindcssClasses": true,
-    "sortHtmlAttributes": "none"
+    "sortHtmlAttributes": "none",
+    "noPhpSyntaxCheck": false
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -124,6 +124,11 @@
           "default": false,
           "markdownDescription": "Collapses multiple blank lines into a single blank line"
         },
+        "bladeFormatter.format.noPhpSyntaxCheck": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Disable PHP syntax check. Enabling this will prevent syntax error reporting even if you write invalid PHP syntax in the Directive."
+        },
         "bladeFormatter.misc.dontShowNewVersionMessage": {
           "type": "boolean",
           "default": false,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -98,6 +98,7 @@ export function activate(context: ExtensionContext) {
                     sortTailwindcssClasses: extConfig.sortTailwindcssClasses,
                     sortHtmlAttributes: extConfig.sortHtmlAttributes ?? 'none',
                     noMultipleEmptyLines: extConfig.noMultipleEmptyLines,
+                    noPhpSyntaxCheck: extConfig.noPhpSyntaxCheck,
                     ...runtimeConfig, // override all settings by runtime config
                     ...tailwindConfig,
                 };

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -24,6 +24,7 @@ export interface RuntimeConfig {
     sortHtmlAttributes?: string;
     tailwindcssConfigPath?: string;
     noMultipleEmptyLines?: boolean;
+    noPhpSyntaxCheck?: boolean;
 }
 
 const configFileNames = [".bladeformatterrc.json", ".bladeformatterrc"];
@@ -58,6 +59,7 @@ export function readRuntimeConfig(filePath: string): RuntimeConfig | undefined {
             sortHtmlAttributes: { type: 'string' },
             tailwindcssConfigPath: { type: 'string' },
             noMultipleEmptyLines: { type: 'boolean' },
+            noPhpSyntaxCheck: { type: 'boolean' },
         },
         additionalProperties: true,
     };

--- a/src/test/fixtures/project/withConfig/noPhpSyntaxCheck/.bladeformatterrc.json
+++ b/src/test/fixtures/project/withConfig/noPhpSyntaxCheck/.bladeformatterrc.json
@@ -1,0 +1,3 @@
+{
+  "noPhpSyntaxCheck": true
+}

--- a/src/test/fixtures/project/withConfig/noPhpSyntaxCheck/formatted.index.blade.php
+++ b/src/test/fixtures/project/withConfig/noPhpSyntaxCheck/formatted.index.blade.php
@@ -1,0 +1,1 @@
+{{ 'john' | ucfirst | substr:0,1 }}

--- a/src/test/fixtures/project/withConfig/noPhpSyntaxCheck/index.blade.php
+++ b/src/test/fixtures/project/withConfig/noPhpSyntaxCheck/index.blade.php
@@ -1,0 +1,1 @@
+{{ 'john' | ucfirst | substr:0,1 }}

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -166,6 +166,14 @@ suite("Extension Test Suite", () => {
         );
     });
 
+    test("Should format file with runtime config / noPhpSyntaxCheck", async function (this: any) {
+        this.timeout(20000);
+        await formatSameAsBladeFormatter(
+            "withConfig/noPhpSyntaxCheck/index.blade.php",
+            "withConfig/noPhpSyntaxCheck/formatted.index.blade.php"
+        );
+    });
+
     test("Format command exists in command list", async function () {
         const commands = await vscode.commands.getCommands();
         assert(commands.includes(ExtensionConstants.formatCommandKey));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds option `noPhpSyntaxCheck`


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/shufo/blade-formatter/issues/691


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
see: https://github.com/shufo/blade-formatter/issues/691
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see tests
