### PR TITLE
fix: can not apply ESM tailwind config 

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "blade-formatter": "^1.33.1",
     "find-config": "^1.0.0",
     "ignore": "^5.2.4",
-    "tailwindcss": "^3.2.7",
+    "tailwindcss": "^3.3.2",
     "vscode-extension-telemetry": "^0.4.5"
   },
   "optionalDependencies": {

--- a/src/test/fixtures/project/withConfig/tailwindConfigESModule/.bladeformatterrc.json
+++ b/src/test/fixtures/project/withConfig/tailwindConfigESModule/.bladeformatterrc.json
@@ -1,0 +1,4 @@
+{
+  "sortTailwindcssClasses": true,
+  "tailwindcssConfigPath": "tailwind.config.js"
+}

--- a/src/test/fixtures/project/withConfig/tailwindConfigESModule/formatted.index.blade.php
+++ b/src/test/fixtures/project/withConfig/tailwindConfigESModule/formatted.index.blade.php
@@ -1,0 +1,3 @@
+<div class="col-start-2 col-end-11 md:col-end-12 xl:col-end-10 xxxl:col-end-8">
+    <h1 class="text-white">Random Stuff</h1>
+</div>

--- a/src/test/fixtures/project/withConfig/tailwindConfigESModule/index.blade.php
+++ b/src/test/fixtures/project/withConfig/tailwindConfigESModule/index.blade.php
@@ -1,0 +1,3 @@
+<div class="md:col-end-12 xl:col-end-10 col-start-2 col-end-11 xxxl:col-end-8">
+    <h1 class="text-white">Random Stuff</h1>
+</div>

--- a/src/test/fixtures/project/withConfig/tailwindConfigESModule/tailwind.config.js
+++ b/src/test/fixtures/project/withConfig/tailwindConfigESModule/tailwind.config.js
@@ -1,0 +1,15 @@
+import defaultTheme from "tailwindcss/defaultTheme";
+
+export default {
+  theme: {
+    screens: {
+      sm: "0",
+      md: "834px",
+      lg: "1024px",
+      xl: "1200px",
+      xxl: "1440px",
+      xxxl: "1900px",
+      ...defaultTheme.screens,
+    },
+  },
+};

--- a/src/test/fixtures/project/withConfig/tailwindConfigError/formatted.index.blade.php
+++ b/src/test/fixtures/project/withConfig/tailwindConfigError/formatted.index.blade.php
@@ -1,3 +1,3 @@
-<div class="xxxl:col-end-8 col-start-2 col-end-11 md:col-end-12 xl:col-end-10">
+<div class="md:col-end-12 xl:col-end-10 col-start-2 col-end-11 xxxl:col-end-8">
     <h1 class="text-white">Random Stuff</h1>
 </div>

--- a/src/test/fixtures/project/withConfig/tailwindConfigError/index.blade.php
+++ b/src/test/fixtures/project/withConfig/tailwindConfigError/index.blade.php
@@ -1,3 +1,3 @@
-<div class="md:col-end-12 xl:col-end-10 col-start-2 col-end-11 xxxl:col-end-8 ">
+<div class="md:col-end-12 xl:col-end-10 col-start-2 col-end-11 xxxl:col-end-8">
     <h1 class="text-white">Random Stuff</h1>
 </div>

--- a/src/test/fixtures/project/withConfig/tailwindConfigError/subdirectory/formatted.index.blade.php
+++ b/src/test/fixtures/project/withConfig/tailwindConfigError/subdirectory/formatted.index.blade.php
@@ -1,3 +1,3 @@
-<div class="xxxl:col-end-8 col-start-2 col-end-11 md:col-end-12 xl:col-end-10">
+<div class="md:col-end-12 xl:col-end-10 col-start-2 col-end-11 xxxl:col-end-8">
     <h1 class="text-white">Random Stuff</h1>
 </div>

--- a/src/test/fixtures/project/withConfig/tailwindConfigError/subdirectory/index.blade.php
+++ b/src/test/fixtures/project/withConfig/tailwindConfigError/subdirectory/index.blade.php
@@ -1,3 +1,3 @@
-<div class="md:col-end-12 xl:col-end-10 col-start-2 col-end-11 xxxl:col-end-8 ">
+<div class="md:col-end-12 xl:col-end-10 col-start-2 col-end-11 xxxl:col-end-8">
     <h1 class="text-white">Random Stuff</h1>
 </div>

--- a/src/test/fixtures/project/withConfig/tailwindConfigError/syntax/formatted.index.blade.php
+++ b/src/test/fixtures/project/withConfig/tailwindConfigError/syntax/formatted.index.blade.php
@@ -1,3 +1,3 @@
-<div class="xxxl:col-end-8 col-start-2 col-end-11 md:col-end-12 xl:col-end-10">
+<div class="md:col-end-12 xl:col-end-10 col-start-2 col-end-11 xxxl:col-end-8">
     <h1 class="text-white">Random Stuff</h1>
 </div>

--- a/src/test/fixtures/project/withConfig/tailwindConfigError/syntax/index.blade.php
+++ b/src/test/fixtures/project/withConfig/tailwindConfigError/syntax/index.blade.php
@@ -1,3 +1,3 @@
-<div class="md:col-end-12 xl:col-end-10 col-start-2 col-end-11 xxxl:col-end-8 ">
+<div class="md:col-end-12 xl:col-end-10 col-start-2 col-end-11 xxxl:col-end-8">
     <h1 class="text-white">Random Stuff</h1>
 </div>

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -159,6 +159,15 @@ suite("Extension Test Suite", () => {
         await config.update('sortTailwindcssClasses', false, true);
     });
 
+    test("Should format file with runtime config / ES Module tailwind config", async function (this: any) {
+        this.timeout(20000);
+        await formatSameAsBladeFormatter(
+            "withConfig/tailwindConfigESModule/index.blade.php",
+            "withConfig/tailwindConfigESModule/formatted.index.blade.php"
+        );
+    });
+
+
     test("Should format file with runtime config / sortHtmlAttributes", async function (this: any) {
         this.timeout(20000);
         await formatSameAsBladeFormatter(

--- a/src/util.ts
+++ b/src/util.ts
@@ -27,7 +27,7 @@ export function requireUncached(moduleName: string) {
         // @ts-ignore
         delete __non_webpack_require__.cache[__non_webpack_require__.resolve(moduleName)];
         // @ts-ignore
-        return __non_webpack_require__(moduleName);
+        import(moduleName);
     } catch (err: any) {
         throw err;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6645,7 +6645,7 @@ table@^6.0.9:
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
 
-tailwindcss@*, tailwindcss@^3.1.8, tailwindcss@^3.2.7:
+tailwindcss@*, tailwindcss@^3.1.8:
   version "3.2.7"
   resolved "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.2.7.tgz"
   integrity sha512-B6DLqJzc21x7wntlH/GsZwEXTBttVSl1FtCzC8WP4oBc/NKef7kaax5jeihkkCEWc831/5NDJ9gRNDK6NEioQQ==


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR bump tailwindcss to 3.3.2, and fixes ESM related bug that can not consume ESM tailwind config.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It should support both ESM/CJS style tailwind config.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Passed CI. Tested on local environment.