### PR TITLE
fix: rollback tailwind config load behaviour

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,6 +196,7 @@
     "blade-formatter": "^1.33.1",
     "find-config": "^1.0.0",
     "ignore": "^5.2.4",
+    "sucrase": "^3.32.0",
     "tailwindcss": "^3.3.2",
     "vscode-extension-telemetry": "^0.4.5"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,7 @@ const REPORT_ISSUE = "Report Issue";
 
 const knownIssuesUrl = "https://github.com/shufo/vscode-blade-formatter/issues";
 const newIssueUrl =
-    "https://github.com/shufo/vscode-blade-formatter/issues/new";
+    "https://github.com/shufo/vscode-blade-formatter/issues/new/choose";
 
 const WASM_ERROR_MESSAGE = "Must invoke loadWASM first.";
 

--- a/src/tailwind.ts
+++ b/src/tailwind.ts
@@ -1,7 +1,6 @@
 import findConfig from 'find-config';
 import path from 'path';
 import { findConfigFile } from './runtimeConfig';
-import { requireUncached } from './util';
 
 const __config__ = 'tailwind.config.js';
 

--- a/src/test/fixtures/project/withConfig/tailwindConfigESModule/package.json
+++ b/src/test/fixtures/project/withConfig/tailwindConfigESModule/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/src/test/fixtures/project/withConfig/tailwindConfigESModuleSyntaxError/.bladeformatterrc.json
+++ b/src/test/fixtures/project/withConfig/tailwindConfigESModuleSyntaxError/.bladeformatterrc.json
@@ -1,0 +1,4 @@
+{
+  "sortTailwindcssClasses": true,
+  "tailwindcssConfigPath": "tailwind.config.js"
+}

--- a/src/test/fixtures/project/withConfig/tailwindConfigESModuleSyntaxError/formatted.index.blade.php
+++ b/src/test/fixtures/project/withConfig/tailwindConfigESModuleSyntaxError/formatted.index.blade.php
@@ -1,0 +1,3 @@
+<div class="xxxl:col-end-8 col-start-2 col-end-11 md:col-end-12 xl:col-end-10">
+    <h1 class="text-white">Random Stuff</h1>
+</div>

--- a/src/test/fixtures/project/withConfig/tailwindConfigESModuleSyntaxError/index.blade.php
+++ b/src/test/fixtures/project/withConfig/tailwindConfigESModuleSyntaxError/index.blade.php
@@ -1,0 +1,3 @@
+<div class="md:col-end-12 xl:col-end-10 col-start-2 col-end-11 xxxl:col-end-8">
+    <h1 class="text-white">Random Stuff</h1>
+</div>

--- a/src/test/fixtures/project/withConfig/tailwindConfigESModuleSyntaxError/package.json
+++ b/src/test/fixtures/project/withConfig/tailwindConfigESModuleSyntaxError/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/src/test/fixtures/project/withConfig/tailwindConfigESModuleSyntaxError/tailwind.config.js
+++ b/src/test/fixtures/project/withConfig/tailwindConfigESModuleSyntaxError/tailwind.config.js
@@ -1,0 +1,12 @@
+export defau {
+  theme: {
+    screens: {
+      sm: "0",
+      md: "834px",
+      lg: "1024px",
+      xl: "1200px",
+      xxl: "1440px",
+      xxxl: "1900px",
+    },
+  },
+};

--- a/src/test/fixtures/project/withConfig/tailwindConfigError/syntax/formatted.index.blade.php
+++ b/src/test/fixtures/project/withConfig/tailwindConfigError/syntax/formatted.index.blade.php
@@ -1,3 +1,3 @@
-<div class="md:col-end-12 xl:col-end-10 col-start-2 col-end-11 xxxl:col-end-8">
+<div class="xxxl:col-end-8 col-start-2 col-end-11 md:col-end-12 xl:col-end-10">
     <h1 class="text-white">Random Stuff</h1>
 </div>

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -167,6 +167,13 @@ suite("Extension Test Suite", () => {
         );
     });
 
+    test("Should format file with runtime config / ES Module tailwind config (Syntax Error)", async function (this: any) {
+        this.timeout(20000);
+        await formatSameAsBladeFormatter(
+            "withConfig/tailwindConfigESModuleSyntaxError/index.blade.php",
+            "withConfig/tailwindConfigESModuleSyntaxError/formatted.index.blade.php"
+        );
+    });
 
     test("Should format file with runtime config / sortHtmlAttributes", async function (this: any) {
         this.timeout(20000);

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,6 @@
 import vscode from "vscode";
+import fs from 'fs';
+import { transform } from 'sucrase';
 
 /**
  * Returns a node module installed with VSCode, or null if it fails.
@@ -26,8 +28,10 @@ export function requireUncached(moduleName: string) {
     try {
         // @ts-ignore
         delete __non_webpack_require__.cache[__non_webpack_require__.resolve(moduleName)];
-        // @ts-ignore
-        import(moduleName);
+
+        const fileContent = fs.readFileSync(moduleName, 'utf8');
+
+        return transform(fileContent, { transforms: ['imports'] });
     } catch (err: any) {
         throw err;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3364,7 +3364,7 @@ espree@^9.5.2:
 
 esprima@^4.0.0, esprima@~4.0.0:
   version "4.0.1"
-  resolved "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 esquery@^1.4.0:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds [`sucrase`](https://github.com/alangpierce/sucrase) to dependencies (already had child dependency but added as explicitly)
Using sucrase to parse tailwind config to detect if it has syntax error.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #739 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
vscode-blade-formatter is currently fallback to default tailwind config if tailwind config has error. (Syntax, module resolution, etc...). So I would like to keep its behaviour.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Passed CI. Tested on local machine.