### PR TITLE
feat: 🎸 option `wrapAttributesMinAttrs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,11 @@
           ],
           "markdownDescription": "The way to wrap attributes"
         },
+        "bladeFormatter.format.wrapAttributesMinAttrs": {
+          "type": "number",
+          "default": 2,
+          "markdownDescription": "Minimum number of html tag attributes for force wrap attribute options. Wrap the first attribute only if `force-expand-multiline` is specified in wrap attributes"
+        },
         "bladeFormatter.format.useTabs": {
           "type": "boolean",
           "default": false,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -111,6 +111,7 @@ export function activate(context: ExtensionContext) {
                     indentSize: extConfig.indentSize,
                     wrapLineLength: extConfig.wrapLineLength,
                     wrapAttributes: extConfig.wrapAttributes,
+                    wrapAttributesMinAttrs: extConfig.wrapAttributesMinAttrs,
                     useTabs: extConfig.useTabs,
                     sortTailwindcssClasses: extConfig.sortTailwindcssClasses,
                     sortHtmlAttributes: extConfig.sortHtmlAttributes ?? "none",

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -18,6 +18,7 @@ export interface RuntimeConfig {
     indentSize?: number;
     wrapLineLength?: number;
     wrapAttributes?: WrapAttributes;
+    wrapAttributesMinAttrs?: number;
     endWithNewline?: boolean;
     useTabs?: boolean;
     sortTailwindcssClasses?: boolean;
@@ -54,6 +55,7 @@ export function readRuntimeConfig(filePath: string): RuntimeConfig | undefined {
                     "preserve-aligned",
                 ],
             },
+            wrapAttributesMinAttrs: { type: "int32" },
             endWithNewline: { type: "boolean" },
             useTabs: { type: "boolean" },
             sortTailwindcssClasses: { type: "boolean" },

--- a/src/test/fixtures/project/withConfig/wrapAttributesMinAttrs/.bladeformatterrc.json
+++ b/src/test/fixtures/project/withConfig/wrapAttributesMinAttrs/.bladeformatterrc.json
@@ -1,0 +1,4 @@
+{
+  "wrapAttributesMinAttrs": 0,
+  "wrapAttributes": "force-expand-multiline"
+}

--- a/src/test/fixtures/project/withConfig/wrapAttributesMinAttrs/formatted.index.blade.php
+++ b/src/test/fixtures/project/withConfig/wrapAttributesMinAttrs/formatted.index.blade.php
@@ -1,0 +1,47 @@
+@extends('frontend.layouts.app')
+@section('head')
+@endsection
+@section('title') foo
+@endsection
+@section('content')
+    <section
+        id="content"
+    >
+        <div
+            class="container mod-users-pd-h"
+        >
+            <div
+                class="pf-user-header"
+            >
+                <div></div>
+                <p>@lang('users.index')</p>
+            </div>
+            <div
+                class="pf-users-branch"
+            >
+                <ul
+                    class="pf-users-branch__list"
+                >
+                    @foreach ($tree as $users)
+                        <li>
+                            <img
+                                src="{{ asset('img/frontend/icon/branch-arrow.svg') }}"
+                                alt="branch_arrow"
+                            >
+                            {{ link_to_route('frontend.users.user.show', $users['name'], $users['_id']) }}
+                        </li>
+                    @endforeach
+                </ul>
+                <div
+                    class="pf-users-branch__btn"
+                >
+                    @can('create', App\Models\User::class)
+                        {!! link_to_route('frontend.users.user.create', __('users.create'), [], ['class' => 'btn']) !!}
+                    @endcan
+                </div>
+            </div>
+        </div>
+    </section>
+@endsection
+@section('footer')
+@stop

--- a/src/test/fixtures/project/withConfig/wrapAttributesMinAttrs/index.blade.php
+++ b/src/test/fixtures/project/withConfig/wrapAttributesMinAttrs/index.blade.php
@@ -1,0 +1,33 @@
+@extends('frontend.layouts.app')
+@section('head')
+@endsection
+@section('title') foo
+@endsection
+@section('content')
+<section id="content">
+    <div class="container mod-users-pd-h">
+        <div class="pf-user-header">
+            <div></div>
+            <p>@lang('users.index')</p>
+        </div>
+        <div class="pf-users-branch">
+            <ul class="pf-users-branch__list">
+                @foreach($tree as $users)
+                <li>
+                    <img src="{{ asset("img/frontend/icon/branch-arrow.svg") }}" alt="branch_arrow">
+                    {{ link_to_route('frontend.users.user.show',$users["name"],$users['_id']) }}
+                </li>
+                @endforeach
+            </ul>
+            <div class="pf-users-branch__btn">
+                @can('create', App\Models\User::class)
+                {!! link_to_route('frontend.users.user.create', __('users.create'), [], ['class' => 'btn']) !!}
+                @endcan
+            </div>
+        </div>
+    </div>
+</section>
+@endsection
+@section('footer')
+@stop
+

--- a/src/test/fixtures/project/withoutConfig/wrapAttributesMinAttrs/formatted.index.blade.php
+++ b/src/test/fixtures/project/withoutConfig/wrapAttributesMinAttrs/formatted.index.blade.php
@@ -1,0 +1,47 @@
+@extends('frontend.layouts.app')
+@section('head')
+@endsection
+@section('title') foo
+@endsection
+@section('content')
+    <section
+        id="content"
+    >
+        <div
+            class="container mod-users-pd-h"
+        >
+            <div
+                class="pf-user-header"
+            >
+                <div></div>
+                <p>@lang('users.index')</p>
+            </div>
+            <div
+                class="pf-users-branch"
+            >
+                <ul
+                    class="pf-users-branch__list"
+                >
+                    @foreach ($tree as $users)
+                        <li>
+                            <img
+                                src="{{ asset('img/frontend/icon/branch-arrow.svg') }}"
+                                alt="branch_arrow"
+                            >
+                            {{ link_to_route('frontend.users.user.show', $users['name'], $users['_id']) }}
+                        </li>
+                    @endforeach
+                </ul>
+                <div
+                    class="pf-users-branch__btn"
+                >
+                    @can('create', App\Models\User::class)
+                        {!! link_to_route('frontend.users.user.create', __('users.create'), [], ['class' => 'btn']) !!}
+                    @endcan
+                </div>
+            </div>
+        </div>
+    </section>
+@endsection
+@section('footer')
+@stop

--- a/src/test/fixtures/project/withoutConfig/wrapAttributesMinAttrs/index.blade.php
+++ b/src/test/fixtures/project/withoutConfig/wrapAttributesMinAttrs/index.blade.php
@@ -1,0 +1,33 @@
+@extends('frontend.layouts.app')
+@section('head')
+@endsection
+@section('title') foo
+@endsection
+@section('content')
+<section id="content">
+    <div class="container mod-users-pd-h">
+        <div class="pf-user-header">
+            <div></div>
+            <p>@lang('users.index')</p>
+        </div>
+        <div class="pf-users-branch">
+            <ul class="pf-users-branch__list">
+                @foreach($tree as $users)
+                <li>
+                    <img src="{{ asset("img/frontend/icon/branch-arrow.svg") }}" alt="branch_arrow">
+                    {{ link_to_route('frontend.users.user.show',$users["name"],$users['_id']) }}
+                </li>
+                @endforeach
+            </ul>
+            <div class="pf-users-branch__btn">
+                @can('create', App\Models\User::class)
+                {!! link_to_route('frontend.users.user.create', __('users.create'), [], ['class' => 'btn']) !!}
+                @endcan
+            </div>
+        </div>
+    </div>
+</section>
+@endsection
+@section('footer')
+@stop
+

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -63,6 +63,39 @@ suite("Extension Test Suite", () => {
         );
     });
 
+    test("Should format file with runtime config / wrapAttributesMinAttrs", async function (this: any) {
+        this.timeout(20000);
+        await formatSameAsBladeFormatter(
+            "withConfig/wrapAttributesMinAttrs/index.blade.php",
+            "withConfig/wrapAttributesMinAttrs/formatted.index.blade.php",
+        );
+    });
+
+    test("Should format file without runtime config / wrapAttributesMinAttrs", async function (this: any) {
+        this.timeout(20000);
+
+        const config = vscode.workspace.getConfiguration(
+            "bladeFormatter.format",
+        );
+        await config.update("sortHtmlAttributes", "custom", true);
+        await config.update(
+            "wrapAttributesMinAttrs",
+            0,
+            true,
+        );
+        await config.update(
+            "wrapAttributes",
+            "force-expand-multiline",
+            true,
+        );
+
+        await formatSameAsBladeFormatter(
+            "withoutConfig/wrapAttributesMinAttrs/index.blade.php",
+            "withoutConfig/wrapAttributesMinAttrs/formatted.index.blade.php",
+        );
+    });
+
+
     test("Should format file with runtime config / wrapLineLength", async function (this: any) {
         this.timeout(20000);
         await formatSameAsBladeFormatter(


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR adds option `wrapAttributesMinAttrs`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This option can controls the position where html tag attributes wraps.
description: `Minimum number of html tag attributes for force wrap attribute options. Wrap the first attribute only if 'force-expand-multiline' is specified in wrap attributes`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

see tests

