### PR TITLE
Added in configuration for componentPrefix to fix #924

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,11 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "If set to 'true', the new version message won't be shown anymore."
+        },
+        "bladeFormatter.format.componentPrefix": {
+          "type": "array",
+          "default": ["x-", "livewire:"],
+          "markdownDescription": "Specify custom prefixes for component names. This changes the format rules applied to custom components e.g. preserve style in attributes."
         }
       }
     }

--- a/schemas/bladeformatterrc.schema.json
+++ b/schemas/bladeformatterrc.schema.json
@@ -55,6 +55,11 @@
 			"description": "Collapses multiple blank lines into a single blank line",
 			"default": false,
 			"type": "boolean"
+		},
+		"componentPrefix": {
+			"description": "Specify custom prefixes for component names. This changes the format rules applied to custom components e.g. preserve style in attributes.",
+			"default": "",
+			"type": "array"
 		}
 	}
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,8 +1,8 @@
 import { Formatter } from "blade-formatter";
 import vscode, {
 	commands,
-	TextEditor,
-	TextEditorEdit,
+	type TextEditor,
+	type TextEditorEdit,
 	window,
 	WorkspaceConfiguration,
 } from "vscode";
@@ -33,6 +33,7 @@ export const formatFromCommand = async (
 			sortTailwindcssClasses: extConfig.sortTailwindcssClasses,
 			sortHtmlAttributes: extConfig.sortHtmlAttributes ?? "none",
 			noMultipleEmptyLines: extConfig.noMultipleEmptyLines,
+			componentPrefix: extConfig.componentPrefix,
 			...runtimeConfig,
 		};
 		const originalText = editor.document.getText();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,6 +119,7 @@ export function activate(context: ExtensionContext) {
 					noPhpSyntaxCheck: extConfig.noPhpSyntaxCheck,
 					indentInnerHtml: extConfig.indentInnerHtml,
 					noSingleQuote: extConfig.noSingleQuote,
+					componentPrefix: extConfig.componentPrefix,
 					...runtimeConfig, // override all settings by runtime config
 					...tailwindConfig,
 				};

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import Ajv, { JTDSchemaType } from "ajv/dist/jtd";
+import Ajv, { type JTDSchemaType } from "ajv/dist/jtd";
 import findConfig from "find-config";
 
 const ajv = new Ajv();
@@ -29,6 +29,7 @@ export interface RuntimeConfig {
 	noMultipleEmptyLines?: boolean;
 	noPhpSyntaxCheck?: boolean;
 	noSingleQuote?: boolean;
+	componentPrefix?: string[];
 }
 
 const configFileNames = [".bladeformatterrc.json", ".bladeformatterrc"];
@@ -67,6 +68,7 @@ export function readRuntimeConfig(filePath: string): RuntimeConfig | undefined {
 			noMultipleEmptyLines: { type: "boolean" },
 			noPhpSyntaxCheck: { type: "boolean" },
 			noSingleQuote: { type: "boolean" },
+			componentPrefix: { elements: { type: "string" } },
 		},
 		additionalProperties: true,
 	};

--- a/src/test/fixtures/project/withConfig/componentPrefix/formatted.index.blade.php
+++ b/src/test/fixtures/project/withConfig/componentPrefix/formatted.index.blade.php
@@ -1,0 +1,4 @@
+<flux:tabs>
+    <flux:tab :disabled="!auth()->user()->can('update', $team)" name="show-types" icon="cog-6-tooth">Test Buttons
+    </flux:tab>
+</flux:tabs>

--- a/src/test/fixtures/project/withConfig/componentPrefix/index.blade.php
+++ b/src/test/fixtures/project/withConfig/componentPrefix/index.blade.php
@@ -1,0 +1,4 @@
+<flux:tabs>
+    <flux:tab :disabled="!auth()->user()->can('update', $team)" name="show-types" icon="cog-6-tooth">Test Buttons
+    </flux:tab>
+</flux:tabs>

--- a/src/test/fixtures/project/withoutConfig/componentPrefix/formatted.index.blade.php
+++ b/src/test/fixtures/project/withoutConfig/componentPrefix/formatted.index.blade.php
@@ -1,0 +1,4 @@
+<flux:tabs>
+    <flux:tab :disabled="!auth()->user()->can('update', $team)" name="show-types" icon="cog-6-tooth">Test Buttons
+    </flux:tab>
+</flux:tabs>

--- a/src/test/fixtures/project/withoutConfig/componentPrefix/index.blade.php
+++ b/src/test/fixtures/project/withoutConfig/componentPrefix/index.blade.php
@@ -1,0 +1,4 @@
+<flux:tabs>
+    <flux:tab :disabled="!auth()->user()->can('update', $team)" name="show-types" icon="cog-6-tooth">Test Buttons
+    </flux:tab>
+</flux:tabs>

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -303,4 +303,24 @@ suite("Extension Test Suite", () => {
 
 		assert.equal(formatted, expected);
 	});
+
+	test("Should format file with componentPrefix option / with config", async function (this: any) {
+		this.timeout(20000);
+		await formatSameAsBladeFormatter(
+			"withConfig/componentPrefix/index.blade.php",
+			"withConfig/componentPrefix/formatted.index.blade.php",
+		);
+	});
+
+	test("Should format file with componentPrefix option / without config", async function (this: any) {
+		this.timeout(20000);
+		const config = vscode.workspace.getConfiguration("bladeFormatter.format");
+		await config.update("componentPrefix", ["flux:"], true);
+
+		await formatSameAsBladeFormatter(
+			"withoutConfig/componentPrefix/index.blade.php",
+			"withoutConfig/componentPrefix/formatted.index.blade.php",
+		);
+		await config.update("componentPrefix", "x-,livewire:", true);
+	});
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added in the configuration option for componentPrefix. This is to allow custom livewire prefixes to be supported and not formatted incorrectly as shown in #924. 

## Related Issue
Fixes: #924

## Motivation and Context
When using libraries like FluxUI - Their components are prefixed with <flux:component> - This PR allows the formatter to use the componentPrefix feature to properly format these components. 

## How Has This Been Tested?
Tests are provided in the PR. Tested functionality locally.

## Screenshots (if appropriate):
