### PR TITLE
ci: Secure release and test pipelines against supply-chain attacks

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -3,20 +3,26 @@ on:
     branches:
       - main
 name: create-release
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: none
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v4
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         id: release
       - name: Setup Node.js
         if: ${{ steps.release.outputs.release_created }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 22.x
       - name: Checkout code
         if: ${{ steps.release.outputs.release_created }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Make envfile
         if: ${{ steps.release.outputs.release_created }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: CI
 on: [push]
+
+permissions:
+  contents: read
+
 jobs:
   test:
     name: CI
@@ -10,26 +14,26 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Make envfile
         run: |
           echo APP_INSIGHT_INSTRUMENT_KEY=example_key >> .env
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 22.x
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         shell: bash
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - uses: actions/cache@v5
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         id: vscode-test-cache
         with:
           path: .vscode-test
@@ -38,7 +42,7 @@ jobs:
         run: yarn install
 
       - name: Run headless test
-        uses: GabrielBB/xvfb-action@v1.7
+        uses: GabrielBB/xvfb-action@b706e4e27b14669b486812790492dc50ca16b465 # v1.7
         with:
           run: yarn run test
         env:


### PR DESCRIPTION
## Summary

This PR hardens shufo/vscode-blade-formatter CI/CD pipelines against supply-chain attacks by pinning all actions to immutable commit SHAs and enforcing least-privilege permissions blocks.

The create-release.yml workflow publishes this extension to the VS Code Marketplace and OpenVSIX - making it a high-value target. A compromised mutable action tag could silently inject malicious code into the published .vsix artifact, affecting all downstream users.

## Changes

### .github/workflows/create-release.yml
- Added top-level permissions block: contents: write, pull-requests: write, id-token: none
- Pinned GoogleCloudPlatform/release-please-action@v4 to @16a9c90856f42705d54a6fda1823352bdc62cf38
- Pinned actions/setup-node@v6 to @53b83947a5a98c8d113130e565377fae1a50d02f
- Pinned actions/checkout@v6 to @de0fac2e4500dabe0009e67214ff5f5447ce83dd

### .github/workflows/test.yml
- Added top-level permissions block: contents: read
- Pinned GabrielBB/xvfb-action@v1.7 to @b706e4e27b14669b486812790492dc50ca16b465
- Pinned actions/checkout@v6 to @de0fac2e4500dabe0009e67214ff5f5447ce83dd
- Pinned actions/setup-node@v6 to @53b83947a5a98c8d113130e565377fae1a50d02f
- Pinned actions/cache@v5 to @668228422ae6a00e4ad889ee87cd7109ec5666a7

## Security Rationale
Mutable version tags allow action authors - or an attacker who gains write access - to silently substitute the code executed in CI. Pinning to immutable commit SHAs eliminates this vector entirely. Adding explicit permissions blocks enforces least privilege, limiting what the GITHUB_TOKEN can access. This is especially critical for the release pipeline which handles Marketplace PATs.

Consistent with OSSF Scorecard, StepSecurity Harden-Runner, and the GitHub Actions Security Hardening Guide.